### PR TITLE
Upgrade to python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.9]
 
     steps:
       - name: Check out repository code

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV APP_DIR /app
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-                    python3.7 python3-setuptools python3-pip && \
+                    python3.9 python3-setuptools python3-pip && \
     rm -rf /var/lib/apt/lists/* && \
     pip3 install --no-cache-dir supervisor==4.2.2 awscli awscli-cwlogs && \
     aws configure set plugins.cwlogs cwlogs && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.21.3
+FROM nginx:1.21.4
 
 ENV APP_DIR /app
 


### PR DESCRIPTION
https://trello.com/c/bsrCIPPZ/214-upgrade-the-router-to-use-python-v39

With the latest update to nginx, we can now use Python 3.9 in the router.
This is the last app using Python 3.7 so after this has been merged, all apps will be using Python >= 3.8